### PR TITLE
Usage of wl-copy in Wayland sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,12 @@ Uses `xclip` to paste username into clipboard and password to primary selection.
 
 The clipboard is emptied after 10s when working with passwords or one-time-passwords
 
-## Previw
+## Preview
 
 By default no preview is shown, but can be toggled using `ctrl-p`. The options default to `hidden,wrap,60%` but can be overridden by variable `BWF_FZF_PREVIEW`.
+
+## Info
+
+For wayland sessions it uses [`wl-copy`](https://man.archlinux.org/man/wl-copy.1)
+
+> wl-copy --clear and wl-copy --paste-once don't always interact well with clipboard managers that are overeager to preserve clipboard contents.

--- a/bwf
+++ b/bwf
@@ -142,9 +142,10 @@ bfw_emptyclipboard() {
    sleep 10
    if [ "$XDG_SESSION_TYPE" = "x1" ]; then
       echo "" | xclip -selection clipboard -i | echo "✔ clipboard emptied"
-   else
-      echo "" | wl-copy -o -c | echo "✔ clipboard emptied"
    fi
+
+   ## workaround for gpaste users
+   which gpaste-client &>/dev/null && gpaste-client delete 0 --use-index
 }
 
 # @description check is session is unlocked, otherwise do unlock

--- a/bwf
+++ b/bwf
@@ -59,14 +59,14 @@ fzf_command () {
 
 # @description gets a single items (json)
 bwf_getsingleitem () {
-      if [ -z "$allItems" ]; then
+   if [ -z "$allItems" ]; then
       allItems=$(bw get item "$account")
    fi
 }
 
 # @description gets all items (json)
 bwf_getitems () {
-      if [ -z "$allItems" ]; then
+   if [ -z "$allItems" ]; then
       allItems=$(bw list items | jq ". | map(select(.type==$item_type))")
    fi
 }
@@ -139,8 +139,12 @@ bwf_getnotes () {
 
 # @description empties the clipboard after 10s
 bfw_emptyclipboard() {
-      sleep 10
-   echo "" | xclip -selection clipboard -i | echo "✔ clipboard emptied"
+   sleep 10
+   if [ "$XDG_SESSION_TYPE" = "x1" ]; then
+      echo "" | xclip -selection clipboard -i | echo "✔ clipboard emptied"
+   else
+      echo "" | wl-copy -o -c | echo "✔ clipboard emptied"
+   fi
 }
 
 # @description check is session is unlocked, otherwise do unlock
@@ -175,7 +179,11 @@ bwf() {
    fi
 
    need bw
-   need xclip
+   if [ "$XDG_SESSION_TYPE" = "x1" ]; then
+      need xclip
+   else
+      need wl-copy
+   fi
    need jq
    need fzf
 
@@ -232,7 +240,13 @@ bwf() {
    # show username per default
    if [ $uflag -gt 0 ] || ([ $uflag -eq 0 ] && [ $pflag -eq 0 ] && [ $nflag -eq 0 ] && [ $tflag -eq 0 ]) ; then
       if [ $xflag -gt 0 ]; then
-         bwf_getuser "$item" | xclip -selection clipboard -i | echo "✔ username copied to clipboard"
+         if [ "$XDG_SESSION_TYPE" = "x1" ]; then
+            bwf_getuser "$item" | xclip -selection clipboard -i | echo "✔ username copied to clipboard"
+            bfw_emptyclipboard
+         else
+            bwf_getuser "$item" | wl-copy -o | echo "✔ username copied to clipboard"
+            bfw_emptyclipboard
+         fi
       else
          bwf_getuser "$item"
       fi
@@ -240,8 +254,13 @@ bwf() {
 
    if [ $pflag -gt 0 ]; then
       if [ $xflag -gt 0 ]; then
-         bwf_getpassword "$item" | xclip -selection clipboard -i | echo "✔ password copied to clipboard"
-         bfw_emptyclipboard
+         if [ "$XDG_SESSION_TYPE" = "x1" ]; then
+            bwf_getpassword "$item" | xclip -selection clipboard -i | echo "✔ password copied to clipboard"
+            bfw_emptyclipboard
+         else
+            bwf_getpassword "$item" | wl-copy -o | echo "✔ password copied to clipboard"
+            bfw_emptyclipboard
+         fi
       else
          bwf_getpassword "$item"
       fi
@@ -249,7 +268,11 @@ bwf() {
 
    if [ $nflag -gt 0 ]; then
       if [ $xflag -gt 0 ]; then
-         bwf_getnotes "$item" | xclip -selection clipboard -i | echo "✔ notes copied to clipboard"
+         if [ "$XDG_SESSION_TYPE" = "x1" ]; then
+            bwf_getnotes "$item" | xclip -selection clipboard -i | echo "✔ notes copied to clipboard"
+         else
+            bwf_getnotes "$item" | wl-copy -o | echo "✔ notes copied to clipboard"
+         fi
       else
          bwf_getnotes "$item"
       fi
@@ -257,8 +280,13 @@ bwf() {
 
    if [ $tflag -gt 0 ]; then
       if [ $xflag -gt 0 ]; then
-         bwf_gettotp "$item" | xclip -selection clipboard -i | echo "✔ onetime password copied to clipboard"
-         bfw_emptyclipboard
+         if [ "$XDG_SESSION_TYPE" = "x1" ]; then
+            bwf_gettotp "$item" | xclip -selection clipboard -i | echo "✔ onetime password copied to clipboard"
+            bfw_emptyclipboard
+         else
+            bwf_gettotp "$item" | wl-copy -o | echo "✔ onetime password copied to clipboard"
+            bfw_emptyclipboard
+         fi
       else
          bwf_gettotp "$item"
       fi


### PR DESCRIPTION
As I am using wayland, `xcopy` does not work. Hence I detect the session type and use `wl-copy`  in case of wayland sessions.

In addition,  I saw that while using Gpaste in my Gnome Workspace, the keyboard was not cleaned properly. So I implemented a "workaround".